### PR TITLE
Added support for DHO800 series oscilloscopes and basic individual channel scaling/gain setting

### DIFF
--- a/wavebin/__main__.py
+++ b/wavebin/__main__.py
@@ -32,7 +32,8 @@ def init():
 
     # Setup waveform capture parser
     wave = WaveParser({
-        "verbose":     args.v
+        "verbose":     args.v,
+        "DHO800":     args.DHO800
     })
 
     # Get subsampling limit
@@ -59,10 +60,10 @@ def init():
         "filter_type": 0,
         "clipping":    False,
         "colours": [
-            (242, 242, 0),
-            (100, 149, 237),
-            (255, 0, 0),
-            (255, 165, 0)
+            (253, 255, 0),
+            (0, 151, 224),
+            (255, 0, 215),
+            (0, 255, 64)
         ]
     })
 
@@ -91,7 +92,7 @@ def parse_args():
     argp.add_argument("-v", action="store_true", help="enable verbose logging mode")
     argp.add_argument("--no-opengl", action="store_true", help="disable hardware accelerated rendering with OpenGL")
     argp.add_argument("--no-limit", action="store_true", help="disable subsampling limit (may cause slow frame rates with large captures)")
-
+    argp.add_argument("--DHO800", action="store_true", help="The Rigol DHO800 family has slightly different header formats")
     return argp.parse_args()
 
 

--- a/wavebin/interface.py
+++ b/wavebin/interface.py
@@ -367,7 +367,8 @@ class QtApp(qt.QApplication):
 class QtSidebar(qt.QTableWidget):
     def __init__(self):
         super(QtSidebar, self).__init__()
-
+        
+        self.selectedChannel=0
         self.setFixedWidth(300)
         self.setColumnCount(2)
         self.setRowCount(0)

--- a/wavebin/interface.py
+++ b/wavebin/interface.py
@@ -396,6 +396,9 @@ class QtSidebar(qt.QTableWidget):
         self.config['parts'].append({"name": "Filter Type", "widget": qt.QComboBox()})
         self.config['parts'].append({"name": "Clipping", "widget": qt.QPushButton("OFF")})
         self.config['parts'].append({"name": "Subsampling", "widget": qt.QSpinBox()})
+        #self.config['parts'].append({"name": "Sinc interpolation", "widget": qt.QPushButton("OFF")})
+        self.config['parts'].append({"name": "Channel", "widget": qt.QComboBox()})
+        self.config['parts'].append({"name": "Scale", "widget": qt.QSpinBox()})
 
         # Add filter dropdown options
         self.config['parts'][0]['widget'].addItem("None")
@@ -411,6 +414,15 @@ class QtSidebar(qt.QTableWidget):
         self.config['parts'][2]['widget'].setMinimum(2)
         self.config['parts'][2]['widget'].valueChanged.connect(self.subsampling_changed)
 
+        # Set channel selection box properties
+        for i in range(4): #self.config['plot'].waveforms
+            self.config['parts'][3]['widget'].addItem("CH"+str(i+1))
+        self.config['parts'][3]['widget'].currentIndexChanged.connect(self.channel_changed)
+
+        #set voltage scaling box properties
+        self.config['parts'][4]['widget'].setMinimum(1)
+        self.config['parts'][4]['widget'].setMaximum(100000)
+        self.config['parts'][4]['widget'].valueChanged.connect(self.gain_changed)
         for i, p in enumerate(self.config['parts']):
             # Add new table row
             self.setRowCount(self.rowCount() + 1)
@@ -485,6 +497,18 @@ class QtSidebar(qt.QTableWidget):
         except AttributeError:
             return
 
+    def channel_changed(self, value):
+        self.selectedChannel=value
+        self.config['parts'][3]['widget'].clearFocus()
+        #self.config['parts'][4]['widget'].setText("CH"+str(value+1)+" scale")
+        self.config['parts'][4]['widget'].setValue(self.config['plot'].config['channel_gain'][self.selectedChannel])
+
+    def gain_changed(self, value):
+        self.config['plot'].config['channel_gain'][self.selectedChannel]=value
+        try:
+            self.config['plot'].update()
+        except AttributeError:
+            return
 
     def toggle(self):
         if self.isHidden():

--- a/wavebin/plot.py
+++ b/wavebin/plot.py
@@ -14,7 +14,7 @@ import pyqtgraph as pg
 class QtPlot(PlotWidget):
     def __init__(self, config):
         self.config = config
-
+        self.config["channel_gain"]=[1,1,1,1] #set gains for 4 channels
         self.log("Initialising plot widget")
         super().__init__()
 
@@ -49,7 +49,7 @@ class QtPlot(PlotWidget):
             else:
                 self.log(f"  Subsampling ({len(w['data'])} -> {int(self.config['subsampling'])})")
                 y = w['data'][:: int( len(w['data']) / self.config['subsampling'] )]
-
+            y=y*self.config['channel_gain'][i]
             # Generate X points
             start = w['header'].x_d_origin
             stop = w['header'].x_d_origin + w['header'].x_d_range


### PR DESCRIPTION
![image](https://github.com/sam210723/wavebin/assets/80003301/a337090f-f179-46b1-9ac7-04c45fa28443)
![image](https://github.com/sam210723/wavebin/assets/80003301/9802ad70-be28-4cb8-a4bf-3f6c74998f66)

- Support for parsing bin files from Rigol DHO800 series scopes. They use a slightly different header structure, so you need to use the flag --DHO800 for the binaries to be processed correctly
- Basic individual channel scaling/gain adjustment. Select channel and input the factor you want to scale values on that channel by.
- Optional thing: trace colors match the yellow, blue, magenta, green color scheme of Tektronix scopes (since it seems to be the most commonly used color scheme)